### PR TITLE
Disallow additional properties (Fix #25)

### DIFF
--- a/lib/lacerda/conversion/data_structure.rb
+++ b/lib/lacerda/conversion/data_structure.rb
@@ -38,6 +38,7 @@ module Lacerda
         @schema['title'] = @id
         add_description_to_json_schema
         add_properties_to_json_schema
+        @schema['additionalProperties'] = false
       end
 
       def to_json

--- a/spec/lib/lacerda/conversion_spec.rb
+++ b/spec/lib/lacerda/conversion_spec.rb
@@ -135,7 +135,8 @@ describe Lacerda::Conversion do
       end
 
       context "have properties with custom types that is" do
-        let(:valid_post){ {'id' => 1, 'title' => 'Servus', 'author_id' => 22 } }
+        let(:valid_post){ {'id' => 1, 'title' => 'Servus', 'author_id' => 22, 'body' => 'We were somewhere around barstow on the edge of the desert', comments: [] } }
+
         let(:invalid_tag){ {'id' => 1, 'variations' => [1]} }
 
         it "nonexistant" do

--- a/spec/lib/lacerda/conversion_spec.rb
+++ b/spec/lib/lacerda/conversion_spec.rb
@@ -135,7 +135,7 @@ describe Lacerda::Conversion do
       end
 
       context "have properties with custom types that is" do
-        let(:valid_post){ {'id' => 1, 'title' => 'Servus', 'author_id' => 22, 'body' => 'We were somewhere around barstow on the edge of the desert', comments: [] } }
+        let(:valid_post){ {'id' => 1, 'title' => 'Servus', 'author_id' => 22 } }
         let(:invalid_tag){ {'id' => 1, 'variations' => [1]} }
 
         it "nonexistant" do

--- a/spec/lib/lacerda/service_spec.rb
+++ b/spec/lib/lacerda/service_spec.rb
@@ -117,23 +117,18 @@ describe Lacerda::Service do
           }.not_to raise_error(JSON::Schema::ValidationError)
         end
 
-        # See https://github.com/moviepilot/lacerda/issues/25 for a more
-        # detailed explanation if this surprises you.
-        it 'fails if it matches two types' do
+        it 'works even if two of the types have (some) fields with the same name' do
           post = valid_post.merge(multiple_matches: [{ num: 1, text: "2" }])
           expect {
             publisher.validate_object_to_publish!('Post', post)
-          }.to raise_error(JSON::Schema::ValidationError)
+          }.not_to raise_error(JSON::Schema::ValidationError)
         end
 
-        # If the object matches one of the types, and another
-        # has no required fields, the object will match both of them.
-        # https://github.com/moviepilot/lacerda/issues/25
-        it 'fails if one of the object has 0 required fields' do
+        it 'does not fail if one of the object has 0 required fields' do
           post = valid_post.merge(unrequired: [{num: 1}])
           expect {
             publisher.validate_object_to_publish!('Post', post)
-          }.to raise_error(JSON::Schema::ValidationError)
+          }.not_to raise_error(JSON::Schema::ValidationError)
         end
 
         it 'rejects arrays with invalid types' do

--- a/spec/lib/lacerda/service_spec.rb
+++ b/spec/lib/lacerda/service_spec.rb
@@ -92,6 +92,12 @@ describe Lacerda::Service do
         expect(result).to be true
       end
 
+      it "rejects objects with additional properties" do
+        valid_post = {id: 1, title: 'My title', body: 'Body', comments: []}
+        result = publisher.validate_object_to_publish('Post', valid_post.merge(foo: 'bar'))
+        expect(result).to be false
+      end
+
       it "rejects an valid object with an exception" do
         invalid_post = {id: 'string', title: 'My title'}
         expect{
@@ -140,7 +146,7 @@ describe Lacerda::Service do
     end
 
     context "to consume" do
-      let(:valid_post) { {id: 1, title: 'My title'} }
+      let(:valid_post) { {title: 'My title'} }
 
       it "knows that it consume a certain object from a service" do
         expect(consumer.consumes_from?('Publisher', 'Post')).to be true
@@ -174,6 +180,13 @@ describe Lacerda::Service do
         expect(
           consumer.validate_object_to_consume('Publisher::Post', valid_post)
         ).to be true
+      end
+      
+      it "rejects objects with additional properties" do
+        expect(
+          consumer.validate_object_to_consume('Publisher::Post', valid_post.merge(id: '1') )
+        ).to be false
+
       end
 
       it "rejects an valid object with an exception" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,6 @@ require 'json'
 require 'rubygems'
 require 'pry'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 require 'simplecov'
 require 'coveralls'
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ require 'lacerda'
 
 RSpec.configure do |config|
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
   # Convert/load test infrastructure, services and specifications
   config.before(:suite) do
     $contracts_dir = File.join(File.dirname(__FILE__), "support", "contracts")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ require 'json'
 require 'rubygems'
 require 'pry'
 
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
+
 require 'simplecov'
 require 'coveralls'
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
@@ -25,8 +28,6 @@ require 'lacerda'
 
 RSpec.configure do |config|
 
-  config.filter_run focus: true
-  config.run_all_when_everything_filtered = true
   # Convert/load test infrastructure, services and specifications
   config.before(:suite) do
     $contracts_dir = File.join(File.dirname(__FILE__), "support", "contracts")

--- a/spec/support/contracts/json_schema_test/app/publish.mson
+++ b/spec/support/contracts/json_schema_test/app/publish.mson
@@ -22,8 +22,10 @@ A post that only has a title, but no text body. Weird, right?
 ## Properties
 - id: 1 (number, required) - The unique identifier for a post
 - title: Work from home (string) - Title of the product
+- body: (string) - Body of the post
 - author_id: 2 (number, required) - User id of author
 - primary_tag: (App::Tag, optional) - Property of custom type
 - tags: (array[Tag]) - An array with a custom type
 - multiple_props: (array[PropA, PropB, string]) - A multitype array
+- comments: (array[string]) - An array with a primitive type
 - numbers: (array[number]) - An array of numbers


### PR DESCRIPTION
After these changes if you add a random property that is not in the contract and try to publish, a validation error will be raised. So you can only publish fields that are specified in the contract.
**This is a breaking change**