### PR TITLE
Drafter as a native extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/drafter"]
+	path = ext/drafter
+	url = http://github.com/apiaryio/drafter.git

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,10 @@
 
 require 'bundler/gem_tasks'
 
+$:.unshift File.join(File.dirname(__FILE__), "lib")
+
+require 'lacerda/tasks'
+
 require 'ffi'
 
 task default: :compile
@@ -21,19 +25,15 @@ task :compile do
     end
     puts 'Compiling...'
     `cd #{File.expand_path('ext/drafter/')} && ./configure --shared && make drafter`
-    status = $CHILD_STATUS.to_i
+    status = $?.to_i
     if status == 0
       puts 'Compiling done.'
     else
-      puts 'Compiling error, exiting.'
-      next # If i'm using exit, abort I have some errors in rake install but gem can be installed
+      raise 'Compiling error, exiting.'
     end
   else
     puts 'Extension already compiled. To recompile set env variable RECOMPILE=true.'
   end
 end
 
-# Bundler.require
-#$:.unshift File.join(File.dirname(__FILE__), "lib")
 
-#require 'lacerda/tasks'

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,38 @@
 #!/usr/bin/env ruby
 
 require 'bundler/gem_tasks'
-Bundler.require
 
-$:.unshift File.join(File.dirname(__FILE__), "lib")
+require 'ffi'
 
-require 'lacerda/tasks'
+task default: :compile
+
+desc 'Compile drafter'
+task :compile do
+  prefix = FFI::Platform.mac? ? '' : 'lib.target/'
+  # Path to compiled drafter library
+  path = File.expand_path("ext/drafter/build/out/Release/#{prefix}libdrafter.#{FFI::Platform::LIBSUFFIX}", File.dirname(__FILE__))
+  puts "Path to library #{path}"
+  if !File.exist?(path) || ENV['RECOMPILE']
+    puts 'The library does not exist, lets compile it'
+    unless File.directory?(File.expand_path('ext/drafter/src'))
+      puts 'Initializing submodules (if required)...'
+      `git submodule update --init --recursive`
+    end
+    puts 'Compiling...'
+    `cd #{File.expand_path('ext/drafter/')} && ./configure --shared && make drafter`
+    status = $CHILD_STATUS.to_i
+    if status == 0
+      puts 'Compiling done.'
+    else
+      puts 'Compiling error, exiting.'
+      next # If i'm using exit, abort I have some errors in rake install but gem can be installed
+    end
+  else
+    puts 'Extension already compiled. To recompile set env variable RECOMPILE=true.'
+  end
+end
+
+# Bundler.require
+#$:.unshift File.join(File.dirname(__FILE__), "lib")
+
+#require 'lacerda/tasks'

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,11 @@
 machine:
+  environment:
+    RECOMPILE: true
   ruby:
     version: '2.3.0'
+checkout:
+  post:
+    - git submodule update --init --recursive
 test:
   post:
     - bundle exec codeclimate-test-reporter 

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,9 @@ machine:
 checkout:
   post:
     - git submodule update --init --recursive
+dependencies:
+  post:
+    - bundle exec rake compile
 test:
   post:
     - bundle exec codeclimate-test-reporter 

--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -14,9 +14,15 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/moviepilot/lacerda"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files << Dir['ext/drafter/**/*'].reject { |f| f =~ /cmdline|test|features|README*|LICENSE|Gemfile*|\.xcode*/   }
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = %(lib ext)
+
+  spec.extensions   = %w(Rakefile)
+
+  spec.required_ruby_version = '>= 2.3.0'
+
   spec.license       = 'MIT'
 
   spec.add_runtime_dependency "activesupport"

--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency "ffi"
   spec.add_runtime_dependency "rake"
 
   spec.add_runtime_dependency "json-schema",   ["~> 2.6.2"]
@@ -37,7 +38,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "guard-bundler"
-  spec.add_development_dependency "ffi"
   spec.add_development_dependency "guard-ctags-bundler"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "rspec"

--- a/lib/lacerda/conversion.rb
+++ b/lib/lacerda/conversion.rb
@@ -101,7 +101,9 @@ module Lacerda
     def self.raise_parsing_errors(mson_file, ast_file)
       parsing_errors = ast_parsing_errors(ast_file)
       return if parsing_errors.empty? 
-      raise Error, parsing_errors.prepend("The following errors were found in #{mson_file}:").join("\n")
+      count = data_structures_from_blueprint_ast(ast_file).count
+      raise Error, parsing_errors.prepend("#{count} data structures were parsed from the AST, but "\
+                                          "the following errors were found in #{mson_file}:").join("\n")
     end
 
     # The structure is of an AST is normally something like

--- a/lib/lacerda/drafter.rb
+++ b/lib/lacerda/drafter.rb
@@ -23,7 +23,9 @@ module Lacerda
   module Drafter
     extend FFI::Library
 
-    ffi_lib 'drafter'
+    prefix = FFI::Platform.mac? ? '' : 'lib.target/'
+
+    ffi_lib File.expand_path("../../../ext/drafter/build/out/Release/#{prefix}libdrafter.#{FFI::Platform::LIBSUFFIX}", __FILE__)
 
     enum :drafter_format, [:DRAFTER_SERIALIZE_YAML, :DRAFTER_SERIALIZE_JSON]
 

--- a/lib/lacerda/tasks.rb
+++ b/lib/lacerda/tasks.rb
@@ -5,6 +5,7 @@ module Lacerda
     include Rake::DSL if defined? Rake::DSL
 
     def install_tasks
+      Bundler.require
       namespace :lacerda do
         desc "Clean up intermediary json files"
         task :cleanup do

--- a/lib/lacerda/tasks.rb
+++ b/lib/lacerda/tasks.rb
@@ -5,7 +5,6 @@ module Lacerda
     include Rake::DSL if defined? Rake::DSL
 
     def install_tasks
-      Bundler.require
       namespace :lacerda do
         desc "Clean up intermediary json files"
         task :cleanup do
@@ -49,6 +48,7 @@ module Lacerda
           # Let's go
           puts "Converting #{files.length} files:"
 
+          Bundler.require
           ok = true
           files.each do |file|
             ok = ok && Lacerda::Conversion.mson_to_json_schema(


### PR DESCRIPTION
This mimics more or less what redsnow was doing, so that when you install lacerda you don't need to install drafter manually yourself