### PR TITLE
Relax json schema version

### DIFF
--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "rake"
 
-  spec.add_runtime_dependency "json-schema",   ["~> 2.6.2"]
+  spec.add_runtime_dependency "json-schema",   ["~> 2.6"]
 
   spec.add_runtime_dependency "colorize"
   spec.add_runtime_dependency "blumquist",     ["~> 0.5"]


### PR DESCRIPTION
There's 2.7.0 already. They follow semver so it should be good.