### PR TITLE
Add id to the schema

### DIFF
--- a/lib/lacerda/conversion.rb
+++ b/lib/lacerda/conversion.rb
@@ -35,19 +35,21 @@ module Lacerda
       # Pluck out Data structures from it
       data_structures = data_structures_from_blueprint_ast(ast_file)
  
+      basename = File.basename(filename)
+      file_type = basename[/(consume|publish)\.mson$/]
+      if file_type.blank?
+        raise Error, "Invalid filename #{basename}, can't tell if it's a publish or consume schema"
+      end
+
       # Generate json schema from each contained data structure
       schema = {
         "$schema"     => "http://json-schema.org/draft-04/schema#",
+        "id"          => file_type.gsub('.mson', '.schema.json'),
         "title"       => service_scope,
         "definitions" => {},
         "type"        => "object",
         "properties"  => {},
       }
-
-      basename = File.basename(filename)
-      if !basename.end_with?("publish.mson") and !basename.end_with?("consume.mson")
-        raise Error, "Invalid filename #{basename}, can't tell if it's a publish or consume schema"
-      end
 
       # The json schema we're constructing contains every known
       # object type in the 'definitions'. So if we have definitions for

--- a/spec/lib/lacerda/conversion_spec.rb
+++ b/spec/lib/lacerda/conversion_spec.rb
@@ -15,6 +15,10 @@ describe Lacerda::Conversion do
         expect(consume_schema['definitions'].keys.sort).to eq ["another_app::post"]
       end
 
+      it "sets id = consume.schema.json" do
+        expect(consume_schema['id']).to eq 'consume.schema.json'
+      end
+
       it "parsed child objects in the consume schema" do
         expect(consume_schema['definitions']['another_app::post']['properties']['primary_tag']['properties']['name']['type']).to eq ["string", "null"]
       end
@@ -48,6 +52,10 @@ describe Lacerda::Conversion do
             .with(filename: f, keep_intermediary_files: false).and_raise
           expect(Lacerda::Conversion.mson_to_json_schema(filename: publish_schema_file, verbose: false)).to be false
         end
+      end
+
+      it "sets id = publish.schema.json" do
+        expect(publish_schema['id']).to eq 'publish.schema.json'
       end
 
       it "doesn't allow names except for publish.mson and consume.mson" do


### PR DESCRIPTION
Instead of seeing:
``` 
[["The property '#/name' of type integer did not match the following type: string in schema 658659b8-41dc-5211-9cb4-0912a8ab1cc4"]
```
You'lll see a slightly less confusing:
```
[["The property '#/name' of type integer did not match the following type: string in schema consume.schema.json"]
```