### PR TITLE
Raise parsing errors

### DIFF
--- a/lib/lacerda/conversion/data_structure/member/type.rb
+++ b/lib/lacerda/conversion/data_structure/member/type.rb
@@ -81,10 +81,6 @@ module Lacerda
             @is_required
           end
 
-          def primitive?
-            PRIMITIVES.include?(type_name.first)
-          end
-
           def nested_types
             error_msg = "This DataStructure::Member is a #{@type_name}, not "\
               'an array, so it cannot have nested types'

--- a/spec/lib/lacerda/conversion_spec.rb
+++ b/spec/lib/lacerda/conversion_spec.rb
@@ -65,18 +65,18 @@ describe Lacerda::Conversion do
         }.to raise_error(Lacerda::Conversion::Error)
       end
 
-      it "allows missing definitions" do
+      it "does not allow missing definitions" do
         missing_definition = File.expand_path("../../../support/contracts/json_schema_test/missing_definition/consume.mson", __FILE__)
         expect { 
           Lacerda::Conversion.mson_to_json_schema!(filename: missing_definition)
-        }.not_to raise_error
+        }.to raise_error(Lacerda::Conversion::Error, /base type 'Tag' is not defined/)
       end
 
       it "allows empty files" do
         empty_mson_file = File.expand_path("../../../support/contracts/empty_test/app/publish.mson", __FILE__)
         expect{
           Lacerda::Conversion.mson_to_json_schema!(filename: empty_mson_file)
-        }.to_not raise_error
+        }.not_to raise_error
       end
 
       it "created a schema file" do
@@ -100,6 +100,13 @@ describe Lacerda::Conversion do
 
       it "found the tag's id property description" do
         expect(publish_schema['definitions']['app::tag']['properties']['id']['description']).to eq "Just an id, carry on"
+      end
+
+      it 'raises errors if the mson is not parseable' do
+        file =  File.expand_path("../../../support/contracts/unparseable/publish.mson", __FILE__)
+        expect{
+          Lacerda::Conversion.mson_to_json_schema!(filename: file)
+        }.to raise_error(Lacerda::Conversion::Error, /base type 'integer' is not defined/)
       end
 
       context "validating objects that" do

--- a/spec/lib/lacerda/service_spec.rb
+++ b/spec/lib/lacerda/service_spec.rb
@@ -119,7 +119,7 @@ describe Lacerda::Service do
           post = valid_post.merge(similar_properties: similar_properties)
           expect {
             publisher.validate_object_to_publish!('Post', post)
-          }.not_to raise_error(JSON::Schema::ValidationError)
+          }.not_to raise_error
         end
 
         it 'does not work if two of the types have (some) fields with the same name' do

--- a/spec/support/contracts/unparseable/publish.mson
+++ b/spec/support/contracts/unparseable/publish.mson
@@ -1,0 +1,9 @@
+# Data Structure
+
+# AnotherApp::Post
+
+We misnamed a property (integer instead of number). Error should be reaised
+
+## Properties
+
+- title: (integer, required)


### PR DESCRIPTION
Covering uncovered code. Turns out there's code to raise parsing exceptions, but it was not added. Probably because it's a breaking change, although I think it makes sense...
It's also related to https://trello.com/c/t4aS4WOM/49-ensure-we-cannot-deploy-if-a-zeta-contract-has-syntax-errors

Should we bump to 2.0?