### PR TITLE
Fix rspec reporter

### DIFF
--- a/lib/lacerda/publish_specification.rb
+++ b/lib/lacerda/publish_specification.rb
@@ -16,6 +16,7 @@ module Lacerda
       Lacerda.validate_reporter(reporter)
       @comparator = Compare::JsonSchema.new(@schema)
       result = @comparator.contains?(consumer.consume.scoped_schema(service), consumer.name)
+      reporter.try(:consume_specification_errors,consumer, errors)
       reporter.try(:consume_specification_satisfied, consumer, result)
       result
     end

--- a/lib/lacerda/reporter.rb
+++ b/lib/lacerda/reporter.rb
@@ -13,9 +13,11 @@ module Lacerda
       # Called before one single publisher is checked against its consumers
     end
 
-    def object_publish_specification_valid(consumed_object, is_valid)
+
+    def object_publish_specification_errors(consumed_object, errors)
       # Called after a consumed object's specification has been checked against
-      # the publisher's specification of that object.
+      # the publisher's specification of that object. It returns an array of
+      # errors
     end
 
     def check_consuming


### PR DESCRIPTION
The rspec reporter was not showing some of the errors, it did not use the  `consume_specification_errors` anywhere. This lead to `true/false` errors which are hard to debug.
Errors now look like this:
```
│
│  2) Lacerda infrastructure contract validation publishers [this] satisfies [that]
│     Failure/Error: expect(error_messages).to be_empty, msg
│
│       expected [this] to satisfy [that] but found these errors:
│         - ERR_MISSING_DEFINITION in [that]/[this]::foobar: The publish specification is missing a ty
│pe defined in the consumer's specification.: (in publish.mson)
```