### PR TITLE
Add option to validate objects without scope

### DIFF
--- a/lib/lacerda/publish_specification.rb
+++ b/lib/lacerda/publish_specification.rb
@@ -26,16 +26,16 @@ module Lacerda
       !!@schema[:definitions][scoped_name]
     end
 
-    def object(name)
-      scoped_name = scopify_name(name)
+    def object(name, scoped: true)
+      object_name = scoped ? scopify_name(name) : Lacerda.underscore(name.to_s)
       schema_dup = Lacerda.deep_copy(@schema)
 
       # It's critical to delete this object from the definitions
       # or else the json validator gem will go into an endless loop
-      object_schema = schema_dup['definitions'].delete scoped_name.to_s
+      object_schema = schema_dup['definitions'].delete object_name.to_s
 
       unless object_schema
-        msg = "Unknown object type: #{scoped_name.to_s.to_json} not in #{schema['definitions'].keys.to_json} - did you specify it in publish.mson?"
+        msg = "Unknown object type: #{object_name.to_s.to_json} not in #{schema['definitions'].keys.to_json} - did you specify it in publish.mson?"
         raise Lacerda::Service::InvalidObjectTypeError.new(msg)
       end
 
@@ -43,7 +43,7 @@ module Lacerda
       # object in case its properties include json pointers
       object_schema['definitions'] = schema_dup['definitions']
 
-      Lacerda::PublishedObject.new(service, scoped_name, object_schema)
+      Lacerda::PublishedObject.new(service, object_name, object_schema)
     end
 
     private

--- a/lib/lacerda/service.rb
+++ b/lib/lacerda/service.rb
@@ -66,15 +66,20 @@ module Lacerda
       @errors.empty?
     end
 
-    def validate_object_to_publish(type, data, scoped: true)
-      validate_object_to_publish!(type, data, scoped: true)
+    def validate_object_to_publish(type, data)
+      validate_object_to_publish!(type, data)
       true
     rescue
       false
     end
 
-    def validate_object_to_publish!(type, data, scoped: true)
-      object_description = @publish.object(type, scoped: scoped)
+    def validate_object_to_publish!(type, data)
+      object_description = @publish.object(type)
+      object_description.validate_data!(data)
+    end
+
+    def validate_internal_publish_object!(type, data)
+      object_description = @publish.object(type, scoped: false)
       object_description.validate_data!(data)
     end
 

--- a/lib/lacerda/service.rb
+++ b/lib/lacerda/service.rb
@@ -66,15 +66,15 @@ module Lacerda
       @errors.empty?
     end
 
-    def validate_object_to_publish(type, data)
-      validate_object_to_publish!(type, data)
+    def validate_object_to_publish(type, data, scoped: true)
+      validate_object_to_publish!(type, data, scoped: true)
       true
     rescue
       false
     end
 
-    def validate_object_to_publish!(type, data)
-      object_description = @publish.object(type)
+    def validate_object_to_publish!(type, data, scoped: true)
+      object_description = @publish.object(type, scoped: scoped)
       object_description.validate_data!(data)
     end
 

--- a/spec/lib/lacerda/consume_specification_spec.rb
+++ b/spec/lib/lacerda/consume_specification_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe Lacerda::ConsumeSpecification do
+  let(:consume_schema_file) do
+    folder = '../../../support/contracts/specification'
+    File.expand_path("#{folder}/consume.schema.json", __FILE__)
+  end
+
+  let(:consume_schema){ JSON.parse(open(consume_schema_file).read) }
+
+  before(:all) do
+    FileUtils.rm(consume_schema_file) rescue nil
+    folder = '../../../support/contracts/specification'
+    consume_mson_file = File.expand_path("#{folder}/consume.mson", __FILE__)
+    Lacerda::Conversion.mson_to_json_schema!(filename: consume_mson_file)
+  end
+
+  describe '#object' do
+    let(:specification) do
+      service = double('Lacerda::Service')
+      expect(service).to receive(:name).and_return('foo').at_most(3).times
+      described_class.new(service, consume_schema)
+    end
+    it 'returns a ConsumeObject for unscoped objects' do
+      object = specification.object('Baz')
+      expect(object).to be_a Lacerda::ConsumedObject
+    end
+
+    it 'returns a ConsumeObject for scoped objects' do
+      object = specification.object('Foo::Bar')
+      expect(object).to be_a Lacerda::ConsumedObject
+    end
+  end
+end

--- a/spec/lib/lacerda/publish_specification_spec.rb
+++ b/spec/lib/lacerda/publish_specification_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe Lacerda::PublishSpecification do
+  let(:publish_schema_file) do
+    folder = '../../../support/contracts/specification'
+    File.expand_path("#{folder}/publish.schema.json", __FILE__)
+  end
+
+  let(:publish_schema){ JSON.parse(open(publish_schema_file).read) }
+
+  before(:all) do
+    FileUtils.rm(publish_schema_file) rescue nil
+    folder = '../../../support/contracts/specification'
+    publish_mson_file = File.expand_path("#{folder}/publish.mson", __FILE__)
+    Lacerda::Conversion.mson_to_json_schema!(filename: publish_mson_file)
+  end
+
+  describe '#object' do
+    let(:specification) do
+      service = double('Lacerda::Service')
+      expect(service).to receive(:name).and_return('foo').at_most(3).times
+      described_class.new(service, publish_schema)
+    end
+    it 'returns a PublishedObject for unscoped objects' do
+      object = specification.object('Baz', scoped: false)
+      expect(object).to be_a Lacerda::PublishedObject
+    end
+
+    it 'returns a PublishedObject for scoped objects' do
+      object = specification.object('Foo::Bar', scoped: true)
+      expect(object).to be_a Lacerda::PublishedObject
+    end
+
+    it 'scopes unscoped objects when scoped: true' do
+      object = specification.object('Bar', scoped: true)
+      expect(object).to be_a Lacerda::PublishedObject
+    end
+  end
+end

--- a/spec/lib/lacerda/service_spec.rb
+++ b/spec/lib/lacerda/service_spec.rb
@@ -79,6 +79,12 @@ describe Lacerda::Service do
         ).to be false
       end
 
+      it "validates internal/unscoped objects" do
+        expect {
+          publisher.validate_internal_publish_object!('PropA', num: 1) 
+        }.not_to raise_error
+      end
+
       it "complains about an unknokwn type with an exception" do
         expect{
           publisher.validate_object_to_publish!('unknown_type', {some: :data})

--- a/spec/support/contracts/specification/consume.mson
+++ b/spec/support/contracts/specification/consume.mson
@@ -1,0 +1,5 @@
+# Foo::Bar
+- baz: (Baz)
+
+# Baz
+- quux: (string, required)

--- a/spec/support/contracts/specification/publish.mson
+++ b/spec/support/contracts/specification/publish.mson
@@ -1,0 +1,5 @@
+# Foo::Bar
+- baz: (Baz)
+
+# Baz
+- quux: (string, required)


### PR DESCRIPTION
In case you want/need to validate just an object without scope.